### PR TITLE
Fix an issue with insert or update operation in batch updates

### DIFF
--- a/component/src/test/java/org/wso2/extension/siddhi/store/redis/test/DefineRedisTableTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/store/redis/test/DefineRedisTableTestCase.java
@@ -21,6 +21,9 @@ package org.wso2.extension.siddhi.store.redis.test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
@@ -31,6 +34,21 @@ import org.wso2.siddhi.core.stream.input.InputHandler;
 public class DefineRedisTableTestCase {
     private static final Logger log = LoggerFactory.getLogger(DefineRedisTableTestCase.class);
     private static final String TABLE_NAME = "fooTable";
+
+    @BeforeClass
+    public static void startTest() {
+        log.info("== Define Redis Table tests started ==");
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        log.info("== Define Redis Table tests completed ==");
+    }
+
+    @BeforeMethod
+    public void init() throws ConnectionUnavailableException {
+        RedisTestUtils.cleanRedisDatabase();
+    }
 
     @Test
     public void defineRedisTableTest1() throws InterruptedException, ConnectionUnavailableException {
@@ -56,7 +74,6 @@ public class DefineRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 2, "Definition/Insertion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test
@@ -84,7 +101,6 @@ public class DefineRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 4, "Definition/Insertion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test
@@ -110,7 +126,6 @@ public class DefineRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 2, "Definition/Insertion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test
@@ -137,6 +152,5 @@ public class DefineRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 4, "Definition/Insertion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 }

--- a/component/src/test/java/org/wso2/extension/siddhi/store/redis/test/DeleteFromRedisTableTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/store/redis/test/DeleteFromRedisTableTestCase.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
@@ -46,6 +47,11 @@ public class DeleteFromRedisTableTestCase {
     @AfterClass
     public static void shutdown() {
         log.info("== Redis Table DELETE tests completed ==");
+    }
+
+    @BeforeMethod
+    public void init() throws ConnectionUnavailableException {
+        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test(description = "deleteFromRedisTableTest1")
@@ -86,7 +92,6 @@ public class DeleteFromRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 2, "Deletion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test(dependsOnMethods = "deleteFromRedisTableTest1")
@@ -126,7 +131,6 @@ public class DeleteFromRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 1, "Deletion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test(dependsOnMethods = "deleteFromRedisTableTest1")
@@ -165,7 +169,6 @@ public class DeleteFromRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 2, "Deletion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test(dependsOnMethods = "deleteFromRedisTableTest3")
@@ -205,7 +208,6 @@ public class DeleteFromRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 2, "Deletion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test(dependsOnMethods = "deleteFromRedisTableTest4", expectedExceptions = SiddhiAppCreationException.class)
@@ -242,7 +244,6 @@ public class DeleteFromRedisTableTestCase {
         deleteStockStream.send(new Object[]{"HTC", 57.6F, 100L});
         await().atMost(5, TimeUnit.SECONDS);
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test(dependsOnMethods = "deleteFromRedisTableTest4")
@@ -283,7 +284,6 @@ public class DeleteFromRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 0, "Deletion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test(dependsOnMethods = "deleteFromRedisTableTest6")
@@ -325,6 +325,5 @@ public class DeleteFromRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 2, "Deletion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 }

--- a/component/src/test/java/org/wso2/extension/siddhi/store/redis/test/InsertIntoRedisTableTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/store/redis/test/InsertIntoRedisTableTestCase.java
@@ -21,6 +21,9 @@ package org.wso2.extension.siddhi.store.redis.test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
@@ -28,8 +31,23 @@ import org.wso2.siddhi.core.exception.ConnectionUnavailableException;
 import org.wso2.siddhi.core.stream.input.InputHandler;
 
 public class InsertIntoRedisTableTestCase {
-    private static final Logger log = LoggerFactory.getLogger(DefineRedisTableTestCase.class);
+    private static final Logger log = LoggerFactory.getLogger(InsertIntoRedisTableTestCase.class);
     private static final String TABLE_NAME = "fooTable";
+
+    @BeforeClass
+    public static void startTest() {
+        log.info("== Redis Table INSERT tests started ==");
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        log.info("== Redis Table INSERT tests completed ==");
+    }
+
+    @BeforeMethod
+    public void init() throws ConnectionUnavailableException {
+        RedisTestUtils.cleanRedisDatabase();
+    }
 
     @Test
     public void insertIntoRedisTableTest1() throws InterruptedException, ConnectionUnavailableException {
@@ -57,7 +75,6 @@ public class InsertIntoRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 6, "Definition/Insertion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test
@@ -85,7 +102,6 @@ public class InsertIntoRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 3, "Definition/Insertion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test
@@ -112,7 +128,6 @@ public class InsertIntoRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 3, "Definition/Insertion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
 
@@ -141,6 +156,5 @@ public class InsertIntoRedisTableTestCase {
         int totalRowsInTable = RedisTestUtils.getRowsFromTable(TABLE_NAME);
         Assert.assertEquals(totalRowsInTable, 6, "Definition/Insertion failed");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 }

--- a/component/src/test/java/org/wso2/extension/siddhi/store/redis/test/ReadFromRedisTableTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/store/redis/test/ReadFromRedisTableTestCase.java
@@ -51,14 +51,15 @@ public class ReadFromRedisTableTestCase {
     }
 
     @BeforeMethod
-    public void init() {
+    public void init() throws ConnectionUnavailableException {
         inEventCount = 0;
         removeEventCount = 0;
         eventArrived = false;
+        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test
-    public void readEventRedisTableTestCase1() throws InterruptedException, ConnectionUnavailableException {
+    public void readEventRedisTableTestCase1() throws InterruptedException {
         //Read events from a Redis table successfully
         log.info("readEventRedisTableTestCase 1 - Read events using primary key");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -124,11 +125,10 @@ public class ReadFromRedisTableTestCase {
         Assert.assertEquals(removeEventCount, 0, "Number of remove events");
         Assert.assertEquals(eventArrived, true, "Event arrived");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test
-    public void readEventRedisTableTestCase2() throws InterruptedException, ConnectionUnavailableException {
+    public void readEventRedisTableTestCase2() throws InterruptedException {
         //Read events from a Redis table successfully
         log.info("readEventRedisTableTestCase 2 - Read event from table using index");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -193,11 +193,10 @@ public class ReadFromRedisTableTestCase {
         Assert.assertEquals(removeEventCount, 0, "Number of remove events");
         Assert.assertEquals(eventArrived, true, "Event arrived");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 
     @Test
-    public void readEventRedisTableTestCase3() throws InterruptedException, ConnectionUnavailableException {
+    public void readEventRedisTableTestCase3() throws InterruptedException {
         //Read events from a Redis table successfully
         log.info("readEventRedisTableTestCase 3 - Read event from a table without primary key using index column");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -256,6 +255,5 @@ public class ReadFromRedisTableTestCase {
         Assert.assertEquals(removeEventCount, 0, "Number of remove events");
         Assert.assertEquals(eventArrived, true, "Event arrived");
         siddhiAppRuntime.shutdown();
-        RedisTestUtils.cleanRedisDatabase();
     }
 }


### PR DESCRIPTION
When insert and update operation is used with a data batch, existing implementation will override all the raws with the final record values.